### PR TITLE
docs: add Claude formatting instructions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,3 +130,39 @@ Each component directory contains a `summary.md` file documenting:
 - `docs/handover/` - Comprehensive architecture documentation
 - `ARCHITECTURE.md` - Migration guide for old vs new style
 - Component-specific `summary.md` files throughout the codebase
+
+## Claude Development Guidelines
+
+This section contains specific instructions for Claude when working on this project.
+
+### Formatting Commands
+
+After making any code modifications, run the appropriate formatting commands:
+
+#### Markdown Files
+- **Format**: Run `make format-md` after modifying any markdown files
+- **Check**: Run `make check-md` to verify markdown files are formatted correctly
+
+#### Rust and TOML Files
+- **Format**: Run `make format` after modifying any Rust (.rs) or TOML (.toml) files
+- **Check**: Run `make check-format` to verify Rust and TOML files are formatted correctly
+
+### Commit Guidelines
+
+**NEVER** add Claude as a co-author in commit messages. Do not include:
+- `Co-Authored-By: Claude <noreply@anthropic.com>`
+- Any other co-author attribution for Claude
+
+**NEVER** use emojis in commit messages.
+
+**Always** wrap commit message titles at 80 characters and body text at 80 characters.
+
+Always verify commit messages before committing and remove any co-author lines referencing Claude.
+
+### Development Workflow
+1. Make your code changes
+2. Run the appropriate formatting command based on file types modified
+3. Verify formatting with check commands if needed
+4. **Verify commit message does not include Claude as co-author**
+5. **Verify commit message contains no emojis and follows 80-character wrap**
+6. Proceed with testing or committing changes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,33 +133,43 @@ Each component directory contains a `summary.md` file documenting:
 
 ## Claude Development Guidelines
 
-This section contains specific instructions for Claude when working on this project.
+This section contains specific instructions for Claude when working on this
+project.
 
 ### Formatting Commands
 
 After making any code modifications, run the appropriate formatting commands:
 
 #### Markdown Files
+
 - **Format**: Run `make format-md` after modifying any markdown files
-- **Check**: Run `make check-md` to verify markdown files are formatted correctly
+- **Check**: Run `make check-md` to verify markdown files are formatted
+  correctly
 
 #### Rust and TOML Files
-- **Format**: Run `make format` after modifying any Rust (.rs) or TOML (.toml) files
-- **Check**: Run `make check-format` to verify Rust and TOML files are formatted correctly
+
+- **Format**: Run `make format` after modifying any Rust (.rs) or TOML (.toml)
+  files
+- **Check**: Run `make check-format` to verify Rust and TOML files are formatted
+  correctly
 
 ### Commit Guidelines
 
 **NEVER** add Claude as a co-author in commit messages. Do not include:
+
 - `Co-Authored-By: Claude <noreply@anthropic.com>`
 - Any other co-author attribution for Claude
 
 **NEVER** use emojis in commit messages.
 
-**Always** wrap commit message titles at 80 characters and body text at 80 characters.
+**Always** wrap commit message titles at 80 characters and body text at 80
+characters.
 
-Always verify commit messages before committing and remove any co-author lines referencing Claude.
+Always verify commit messages before committing and remove any co-author lines
+referencing Claude.
 
 ### Development Workflow
+
 1. Make your code changes
 2. Run the appropriate formatting command based on file types modified
 3. Verify formatting with check commands if needed


### PR DESCRIPTION
Add CLAUDE.md with makefile commands for formatting:
- make format-md for markdown files
- make format for Rust/TOML files
- make check-md and make check-format for verification

Include commit guidelines:
- Never add Claude as co-author
- Never use emojis in commit messages
- Always wrap titles and body at 80 characters