### PR TITLE
Fix broken links for cargo doc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,8 @@ DOCKER_ORG ?= openmina
 # PostgreSQL configuration for archive node
 OPEN_ARCHIVE_ADDRESS ?= http://localhost:3007
 PG_USER ?= openmina
-PG_PW 	?= openminaopenmina
-PG_DB 	?= openmina_archive
+PG_PW	?= openminaopenmina
+PG_DB	?= openmina_archive
 PG_HOST	?= localhost
 PG_PORT	?= 5432
 
@@ -345,7 +345,7 @@ docs-rust: ## Generate Rust API documentation
 	@echo "Generating Rust API documentation..."
 	# Using nightly with --enable-index-page to generate workspace index
 	# See: https://github.com/rust-lang/cargo/issues/8229
-	@DATABASE_URL="sqlite::memory:" RUSTDOCFLAGS="--enable-index-page -Zunstable-options" cargo +nightly doc --no-deps --document-private-items --workspace --exclude heartbeats-processor --lib --bins
+	@DATABASE_URL="sqlite::memory:" RUSTDOCFLAGS="--enable-index-page -Zunstable-options -D warnings" cargo +nightly doc --no-deps --document-private-items --workspace --exclude heartbeats-processor --lib --bins
 	@echo "Rust documentation generated in target/doc/"
 	@echo "Entry point: target/doc/index.html"
 

--- a/ledger/src/base.rs
+++ b/ledger/src/base.rs
@@ -69,7 +69,7 @@ pub trait BaseLedger {
     where
         F: FnMut(B, &Account) -> B;
 
-    /// the set of [account_id]s are ledger elements to skip during the fold,
+    /// the set of `account_id`s are ledger elements to skip during the fold,
     /// because they're in a mask
     fn fold_with_ignored_accounts<B, F>(&self, ignoreds: HashSet<AccountId>, init: B, fun: F) -> B
     where
@@ -103,7 +103,7 @@ pub trait BaseLedger {
         account: Account,
     ) -> Result<GetOrCreated, DatabaseError>;
 
-    /// the ledger should not be used after calling [close]
+    /// the ledger should not be used after calling `close`
     fn close(&self);
 
     /// for account locations in the ledger, the last (rightmost) filled location
@@ -111,7 +111,7 @@ pub trait BaseLedger {
 
     fn get_uuid(&self) -> Uuid;
 
-    /// return Some [directory] for ledgers that use a file system, else None
+    /// return Some `directory` for ledgers that use a file system, else None
     fn get_directory(&self) -> Option<PathBuf>;
 
     fn get(&self, addr: Address) -> Option<Box<Account>>;

--- a/ledger/src/generators/zkapp_command_builder.rs
+++ b/ledger/src/generators/zkapp_command_builder.rs
@@ -21,8 +21,8 @@ pub fn get_transaction_commitments(
     (txn_commitment, full_txn_commitment)
 }
 
-/// replace dummy signatures, proofs with valid ones for fee payer, other zkapp_command
-/// [keymap] maps compressed public keys to private keys
+/// Replace dummy signatures, proofs with valid ones for fee payer, other zkapp_command
+/// `keymap` maps compressed public keys to private keys
 ///
 /// <https://github.com/MinaProtocol/mina/blob/f7f6700332bdfca77d9f3303e9cf3bc25f997e09/src/lib/zkapp_command_builder/zkapp_command_builder.ml#L94>
 pub fn replace_authorizations(

--- a/ledger/src/scan_state/fee_excess.rs
+++ b/ledger/src/scan_state/fee_excess.rs
@@ -16,16 +16,16 @@
 //! excesses can be represented by excesses in (at most) 2 tokens.
 //! Consider, for example, any consecutive subsequence of the transactions
 //!
-//! ..[txn@2][ft@2][txn@3][txn@3][ft@3][txn@4][ft@4][txn@5][txn@5][ft@5][txn@6][ft@6]..
+//! `..[txn@2][ft@2][txn@3][txn@3][ft@3][txn@4][ft@4][txn@5][txn@5][ft@5][txn@6][ft@6]..`
 //!
-//! where [txn@i] and [ft@i] are transactions and fee transfers respectively
+//! where `[txn@i]` and `[ft@i]` are transactions and fee transfers respectively
 //! paid in token i.
 //! The only groups which may have non-zero fee excesses are those which
 //! contain the start and end of the subsequence.
 //!
-//! The code below also defines a canonical representation where fewer than 2
-//! tokens have non-zero excesses. See [rebalance] below for details and the
-//! implementation.
+//! The code below also defines a canonical representation where fewer
+//! than 2 tokens have non-zero excesses. See the internal function
+//! `FeeExcess::rebalance` below for details and the implementation.
 //!
 //!
 //! Port of the implementation from:

--- a/ledger/src/scan_state/transaction_logic.rs
+++ b/ledger/src/scan_state/transaction_logic.rs
@@ -626,7 +626,7 @@ impl Memo {
     }
 
     pub fn hash(&self) -> Fp {
-        use ::poseidon::hash::{hash_with_kimchi, legacy};
+        use poseidon::hash::{hash_with_kimchi, legacy};
 
         // For some reason we are mixing legacy inputs and "new" hashing
         let mut inputs = legacy::Inputs::new();
@@ -5683,7 +5683,7 @@ where
 
 /// apply zkapp command fee payer's while stubbing out the second pass ledger
 /// CAUTION: If you use the intermediate local states, you MUST update the
-///   [will_succeed] field to [false] if the [status] is [Failed].*)
+/// [`LocalStateEnv::will_succeed`] field to `false` if the `status` is [`TransactionStatus::Failed`].*)
 pub fn apply_zkapp_command_first_pass_aux<A, F, L>(
     constraint_constants: &ConstraintConstants,
     global_slot: Slot,
@@ -6313,14 +6313,14 @@ impl FailureCollection {
 }
 
 /// Structure of the failure status:
-///  I. No fee transfer and coinbase transfer fails: [[failure]]
+///  I. No fee transfer and coinbase transfer fails: `[[failure]]`
 ///  II. With fee transfer-
 ///   Both fee transfer and coinbase fails:
-///     [[failure-of-fee-transfer]; [failure-of-coinbase]]
+///     `[[failure-of-fee-transfer]; [failure-of-coinbase]]`
 ///   Fee transfer succeeds and coinbase fails:
-///     [[];[failure-of-coinbase]]
+///     `[[];[failure-of-coinbase]]`
 ///   Fee transfer fails and coinbase succeeds:
-///     [[failure-of-fee-transfer];[]]
+///     `[[failure-of-fee-transfer];[]]`
 ///
 /// <https://github.com/MinaProtocol/mina/blob/2ee6e004ba8c6a0541056076aab22ea162f7eb3a/src/lib/transaction_logic/mina_transaction_logic.ml#L2022>
 fn apply_coinbase<L>(
@@ -7548,7 +7548,7 @@ pub fn cons_signed_command_payload(
 ) -> ReceiptChainHash {
     // Note: Not sure why they use the legacy way of hashing here
 
-    use ::poseidon::hash::legacy;
+    use poseidon::hash::legacy;
 
     let ReceiptChainHash(last_receipt_chain_hash) = last_receipt_chain_hash;
     let union = TransactionUnionPayload::of_user_command_payload(command_payload);
@@ -7569,7 +7569,7 @@ pub fn checked_cons_signed_command_payload(
     use crate::proofs::transaction::{
         legacy_input::CheckedLegacyInput, transaction_snark::checked_legacy_hash,
     };
-    use ::poseidon::hash::legacy;
+    use poseidon::hash::legacy;
 
     let mut inputs = payload.to_checked_legacy_input_owned(w);
     inputs.append_field(last_receipt_chain_hash.0);

--- a/node/src/ledger/ledger_service.rs
+++ b/node/src/ledger/ledger_service.rs
@@ -1411,7 +1411,7 @@ impl LedgerSyncState {
             .ok_or_else(|| format!("Missing sync snarked ledger {}", hash))
     }
 
-    /// Returns a [Mask] instance for the snarked ledger with [hash]. If it doesn't
+    /// Returns a [Mask] instance for the snarked ledger with `hash`. If it doesn't
     /// exist a new instance is created.
     fn snarked_ledger_mut(&mut self, hash: LedgerHash) -> Result<&mut Mask, InvalidBigInt> {
         let hash_fp = hash.to_field()?;

--- a/p2p/src/p2p_state.rs
+++ b/p2p/src/p2p_state.rs
@@ -515,64 +515,64 @@ type OptionalCallback<T> = Option<Callback<T>>;
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct P2pCallbacks {
-    /// Callback for [`P2pChannelsTransactionAction::Received`]
+    /// Callback for [`crate::channels::transaction::P2pChannelsTransactionAction::Received`]
     pub on_p2p_channels_transaction_received: OptionalCallback<(PeerId, Box<TransactionInfo>)>,
-    /// Callback for [`P2pChannelsTransactionAction::Libp2pReceived`]
+    /// Callback for [`crate::channels::transaction::P2pChannelsTransactionAction::Libp2pReceived`]
     pub on_p2p_channels_transactions_libp2p_received: OptionalCallback<(
         PeerId,
         Vec<TransactionWithHash>,
         P2pNetworkPubsubMessageCacheId,
     )>,
-    /// Callback for [`P2pChannelsSnarkJobCommitmentAction::Received`]
+    /// Callback for [`crate::channels::snark_job_commitment::P2pChannelsSnarkJobCommitmentAction::Received`]
     pub on_p2p_channels_snark_job_commitment_received:
         OptionalCallback<(PeerId, Box<SnarkJobCommitment>)>,
 
-    /// Callback for [`P2pChannelsSnarkAction::Received`]
+    /// Callback for [`crate::channels::snark::P2pChannelsSnarkAction::Received`]
     pub on_p2p_channels_snark_received: OptionalCallback<(PeerId, Box<SnarkInfo>)>,
-    /// Callback for [`P2pChannelsSnarkAction::Libp2pReceived`]
+    /// Callback for [`crate::channels::snark::P2pChannelsSnarkAction::Libp2pReceived`]
     pub on_p2p_channels_snark_libp2p_received: OptionalCallback<(PeerId, Box<Snark>)>,
 
-    /// Callback for [`P2pChannelsBestTipAction::RequestReceived`]
+    /// Callback for [`crate::channels::best_tip::P2pChannelsBestTipAction::RequestReceived`]
     pub on_p2p_channels_best_tip_request_received: OptionalCallback<PeerId>,
 
-    /// Callback for [`P2pDisconnectionAction::Finish`]
+    /// Callback for [`crate::disconnection::P2pDisconnectionAction::Finish`]
     pub on_p2p_disconnection_finish: OptionalCallback<PeerId>,
 
     /// TODO: these 2 should be set by `P2pConnectionOutgoingAction::Init`
-    /// Callback for [`P2pConnectionOutgoingAction::Error`]
+    /// Callback for [`crate::connection::outgoing::P2pConnectionOutgoingAction::Error`]
     pub on_p2p_connection_outgoing_error: OptionalCallback<(RpcId, P2pConnectionOutgoingError)>,
-    /// Callback for [`P2pConnectionOutgoingAction::Success`]
+    /// Callback for [`crate::connection::outgoing::P2pConnectionOutgoingAction::Success`]
     pub on_p2p_connection_outgoing_success: OptionalCallback<RpcId>,
 
     /// TODO: these 3 should be set by `P2pConnectionIncomingAction::Init`
-    /// Callback for [`P2pConnectionIncomingAction::Error`]
+    /// Callback for [`crate::connection::incoming::P2pConnectionIncomingAction::Error`]
     pub on_p2p_connection_incoming_error: OptionalCallback<(RpcId, String)>,
-    /// Callback for [`P2pConnectionIncomingAction::Success`]
+    /// Callback for [`crate::connection::incoming::P2pConnectionIncomingAction::Success`]
     pub on_p2p_connection_incoming_success: OptionalCallback<RpcId>,
-    /// Callback for [`P2pConnectionIncomingAction::AnswerReady`]
+    /// Callback for [`crate::connection::incoming::P2pConnectionIncomingAction::AnswerReady`]
     pub on_p2p_connection_incoming_answer_ready:
         OptionalCallback<(RpcId, PeerId, P2pConnectionResponse)>,
 
-    /// Callback for [`P2pPeerAction::BestTipUpdate`]
+    /// Callback for [`crate::peer::P2pPeerAction::BestTipUpdate`]
     pub on_p2p_peer_best_tip_update:
         OptionalCallback<BlockWithHash<Arc<v2::MinaBlockBlockStableV2>>>,
 
-    /// Callback for [`P2pChannelsRpcAction::Ready`]
+    /// Callback for [`crate::channels::rpc::P2pChannelsRpcAction::Ready`]
     pub on_p2p_channels_rpc_ready: OptionalCallback<PeerId>,
-    /// Callback for [`P2pChannelsRpcAction::Timeout`]
+    /// Callback for [`crate::channels::rpc::P2pChannelsRpcAction::Timeout`]
     pub on_p2p_channels_rpc_timeout: OptionalCallback<(PeerId, P2pRpcId)>,
-    /// Callback for [`P2pChannelsRpcAction::ResponseReceived`]
+    /// Callback for [`crate::channels::rpc::P2pChannelsRpcAction::ResponseReceived`]
     pub on_p2p_channels_rpc_response_received:
         OptionalCallback<(PeerId, P2pRpcId, Option<Box<P2pRpcResponse>>)>,
-    /// Callback for [`P2pChannelsRpcAction::RequestReceived`]
+    /// Callback for [`crate::channels::rpc::P2pChannelsRpcAction::RequestReceived`]
     pub on_p2p_channels_rpc_request_received:
         OptionalCallback<(PeerId, P2pRpcId, Box<P2pRpcRequest>)>,
 
-    /// Callback for [`P2pChannelsStreamingRpcAction::Ready`]
+    /// Callback for [`crate::channels::streaming_rpc::P2pChannelsStreamingRpcAction::Ready`]
     pub on_p2p_channels_streaming_rpc_ready: OptionalCallback<()>,
-    /// Callback for [`P2pChannelsStreamingRpcAction::Timeout`]
+    /// Callback for [`crate::channels::streaming_rpc::P2pChannelsStreamingRpcAction::Timeout`]
     pub on_p2p_channels_streaming_rpc_timeout: OptionalCallback<(PeerId, P2pRpcId)>,
-    /// Callback for [`P2pChannelsStreamingRpcAction::ResponseReceived`]
+    /// Callback for [`crate::channels::streaming_rpc::P2pChannelsStreamingRpcAction::ResponseReceived`]
     pub on_p2p_channels_streaming_rpc_response_received:
         OptionalCallback<(PeerId, P2pRpcId, Option<P2pStreamingRpcResponseFull>)>,
 

--- a/p2p/testing/src/utils.rs
+++ b/p2p/testing/src/utils.rs
@@ -224,7 +224,7 @@ where
 ///
 /// Function `f` extract peer_id from a Rust event.
 ///
-/// See [`super::predicates::all_nodes_with_items`].
+/// See [`super::predicates::all_nodes_with_value`].
 pub async fn try_wait_for_all_node_peer<I, F>(
     cluster: &mut Cluster,
     nodes_peers: I,
@@ -246,7 +246,7 @@ where
 ///
 /// Function `f` extract value `v` from a Rust event.
 ///
-/// See [`super::predicates::all_nodes_with_items`].
+/// See [`super::predicates::all_nodes_with_value`].
 pub async fn try_wait_for_all_nodes_with_value<T, I, F>(
     cluster: &mut Cluster,
     nodes_values: I,


### PR DESCRIPTION
`make docs-rust` was generating quite a few warnings with broken links. This PR fixes broken internal links.