### PR TITLE
docs: add shellcheck to system dependencies installation

### DIFF
--- a/.github/workflows/test-docs-scripts.yml
+++ b/.github/workflows/test-docs-scripts.yml
@@ -69,6 +69,7 @@ jobs:
           protoc --version
           sqlite3 --version
           wasm-pack --version
+          shellcheck --version
 
   macos:
     name: Test System Setup Scripts (${{ matrix.os }})
@@ -125,6 +126,7 @@ jobs:
           protoc --version
           sqlite3 --version
           wasm-pack --version
+          shellcheck --version
 
   docker-ubuntu:
     name: Test Docker Setup Script (${{ matrix.os }})

--- a/website/docs/developers/scripts/setup/install-system-deps-macos.sh
+++ b/website/docs/developers/scripts/setup/install-system-deps-macos.sh
@@ -10,4 +10,5 @@ brew install \
     protobuf \
     sqlite \
     git \
-    curl
+    curl \
+    shellcheck

--- a/website/docs/developers/scripts/setup/install-system-deps.sh
+++ b/website/docs/developers/scripts/setup/install-system-deps.sh
@@ -6,4 +6,5 @@ sudo apt install -y \
     protobuf-compiler \
     sqlite3 \
     git \
-    curl
+    curl \
+    shellcheck


### PR DESCRIPTION
## Summary

- Add shellcheck to Ubuntu/Debian system dependencies script
- Add shellcheck to macOS system dependencies script via Homebrew  
- Update CI workflow to verify shellcheck installation in doc testing

This ensures shellcheck is available for developers following the setup documentation and validates the installation works correctly across all supported platforms.