### PR TITLE
CI: set fail-fast to false to prevent cancelling other jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -115,6 +115,7 @@ jobs:
     # NOTE: If you add or remove platforms from this matrix, make sure to update
     # the documentation at website/docs/developers/getting-started.mdx
     strategy:
+      fail-fast: false  # Allow other platforms to continue if one fails
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04, ubuntu-24.04-arm, macos-latest]
     runs-on: ${{ matrix.os }}
@@ -146,6 +147,7 @@ jobs:
     # NOTE: If you add or remove platforms from this matrix, make sure to update
     # the documentation at website/docs/developers/getting-started.mdx
     strategy:
+      fail-fast: false  # Allow other platforms to continue if one fails
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04, ubuntu-24.04-arm, macos-latest]
     runs-on: ${{ matrix.os }}
@@ -168,6 +170,7 @@ jobs:
     # NOTE: If you add or remove platforms from this matrix, make sure to update
     # the documentation at website/docs/developers/getting-started.mdx
     strategy:
+      fail-fast: false  # Allow other platforms to continue if one fails
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04, ubuntu-24.04-arm, macos-latest]
     runs-on: ${{ matrix.os }}
@@ -205,6 +208,7 @@ jobs:
     # NOTE: If you add or remove platforms from this matrix, make sure to update
     # the documentation at website/docs/developers/getting-started.mdx
     strategy:
+      fail-fast: false  # Allow other platforms to continue if one fails
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04, ubuntu-24.04-arm, macos-latest]
     runs-on: ${{ matrix.os }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use consistent `use` statements for fields. Replace `mina_hasher::Fp` with
   `mina_curves::pasta::Fp`.
   ([#1269](https://github.com/o1-labs/openmina/pull/1269/)).
+- **CI**: set fail-fast to false to prevent cancellation of other jobs
+  ([#1305](https://github.com/o1-labs/openmina/pull/1305))
 
 ### Fixed
 


### PR DESCRIPTION
Fix #1304
See
https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idstrategyfail-fast